### PR TITLE
Normalize CI/CD workflows

### DIFF
--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -1,16 +1,17 @@
-# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: 'Dependabot auto approval'
 
 on:
-  pull_request_target
+  pull_request_target:
 
 permissions:
   pull-requests: write
-  contents:      write
+  contents: write
 
 jobs:
-  package:
+  approve:
+    # yamllint disable-line
     uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -5,11 +5,12 @@ name: 'Dependabot auto approval'
 
 on:
   pull_request_target
+
 permissions:
   pull-requests: write
-  contents: write
+  contents:      write
 
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
-name: 'Automatically relase patch versions.'
+name: 'Auto Release'
 
 on:
   schedule: # Run every day at 12:00 UTC
@@ -13,5 +13,6 @@ permissions:
 
 jobs:
   release:
+    # yamllint disable-line
     uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
+---
+name: 'Automatically relase patch versions.'
+
+on:
+  schedule: # Run every day at 12:00 UTC
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,12 @@ on:
 
 permissions:
   pull-requests: read
-  contents:      write
-  packages:      write
+  contents: write
+  packages: write
 
 jobs:
   ci:
+    # yamllint disable-line
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     with:
       release-type:   library

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,14 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+  contents:      write
+  packages:      write
+
 jobs:
   ci:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@766cd1914571123cc26ab6e0f1782c784dc4f11f # v4.4.28
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     with:
       release-type:   library
       yaml-lint-skip: false

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -11,7 +11,12 @@ on:
     types:
       - opened
 
+permissions:
+  contents:      read
+  issues:        write
+  pull-requests: write
+
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+    uses: xmidt-org/shared-go/.github/workflows/proj.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/proj.yml
+++ b/.github/workflows/proj.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: 'PROJ: xmidt-team'
@@ -12,11 +12,12 @@ on:
       - opened
 
 permissions:
-  contents:      read
-  issues:        write
+  contents: read
+  issues: write
   pull-requests: write
 
 jobs:
-  package:
+  proj:
+    # yamllint disable-line
     uses: xmidt-org/shared-go/.github/workflows/proj.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit


### PR DESCRIPTION
## Summary

This PR normalizes the CI/CD workflows to match xmidt-org standards as outlined in issue #43.

### Changes Made

- **ci.yml**: Added top-level `permissions:` block with `pull-requests: read`, `contents: write`, `packages: write` and updated workflow reference to v4.9.41
- **auto-releaser.yml**: Created new workflow file referencing `xmidt-org/shared-go/.github/workflows/auto-releaser.yml` with `permissions: { contents: write }`
- **approve-dependabot.yml**: Renamed from `dependabot-approver.yml` and updated to reference `xmidt-org/shared-go/.github/workflows/approve-dependabot.yml`
- **proj-xmidt-team.yml**: Updated to reference `xmidt-org/shared-go/.github/workflows/proj.yml` (as proj-xmidt-team.yml doesn't exist in shared-go) and added proper permissions block with `contents: read`, `issues: write`, `pull-requests: write`

All workflow references are pinned to commit SHA `aff0471aa7e2f96ddb059beb178f63747a7cc57e` (v4.9.41).

Resolves #43